### PR TITLE
Bugfix/issue 17

### DIFF
--- a/src/main/java/com/ticktock/controller/BreakManager.java
+++ b/src/main/java/com/ticktock/controller/BreakManager.java
@@ -49,9 +49,9 @@ public class BreakManager {
     public long getTotalBreakTime() {
         long totalBreakTime = 0;
         for (SessionDuration duration : breakDurations) {
-            totalBreakTime += duration.getDurationPassed().getSeconds();
+            totalBreakTime += duration.getDurationPassed().toMillis();
         }
-        return totalBreakTime;
+        return totalBreakTime / 1000;
     }
 
     public List<SessionDuration> getBreakDurations() {


### PR DESCRIPTION
If you had 2 breaks that are 1.5 seconds each, the total break time returned should be 3 seconds but it returns 2. This fix changes the logic slightly to deal with this bug by interacting with the time at the milliseconds level.

Refer to #17 for details