### PR TITLE
resolve issue by stopping break before ending session break ongoing

### DIFF
--- a/src/main/java/com/ticktock/controller/MainController.java
+++ b/src/main/java/com/ticktock/controller/MainController.java
@@ -183,6 +183,13 @@ public class MainController {
             return;
         }
 
+        /*
+        Handle the stopping and storing of ongoing break when session is ended during a break
+         */
+        if (currentSession.isOnBreak()) {
+            currentSession.stopBreak();
+        }
+
         stopUIUpdater();
 
         String module = currentSession.getSessionTagging().getModuleName();


### PR DESCRIPTION
**Modifications:**
- In the function for handling session ending (handleEnd) in MainController, if the current session is on a break, stop the break first before proceeding with the rest of the session ending process.

<img width="281" alt="image" src="https://github.com/user-attachments/assets/6188e023-250e-416b-a081-6f2be94d1a52" />

<img width="223" alt="image" src="https://github.com/user-attachments/assets/040e24f6-95aa-44a0-b5a1-6e33dff34def" />

